### PR TITLE
refactor: Unify UserID and MorningCallID types across all layers for type safety

### DIFF
--- a/internal/domain/morningcall.go
+++ b/internal/domain/morningcall.go
@@ -7,8 +7,8 @@ import (
 // アラーム情報
 type MorningCall struct {
 	ID         MorningCallID
-	SenderID   string
-	ReceiverID string
+	SenderID   UserID
+	ReceiverID UserID
 	Time       time.Time
 	Message    string
 	Status     MorningCallStatus

--- a/internal/domain/morningcall_validation.go
+++ b/internal/domain/morningcall_validation.go
@@ -5,17 +5,17 @@ import (
 )
 
 // IsSender checks if the specified user is the sender of this morning call
-func (rcv *MorningCall) IsSender(userID string) bool {
+func (rcv *MorningCall) IsSender(userID UserID) bool {
 	return rcv.SenderID == userID
 }
 
 // IsReceiver checks if the specified user is the receiver of this morning call
-func (rcv *MorningCall) IsReceiver(userID string) bool {
+func (rcv *MorningCall) IsReceiver(userID UserID) bool {
 	return rcv.ReceiverID == userID
 }
 
 // CanUpdate checks if the morning call can be updated
-func (rcv *MorningCall) CanUpdate(userID string) NGReason {
+func (rcv *MorningCall) CanUpdate(userID UserID) NGReason {
 	// 送信者のみが更新可能
 	if !rcv.IsSender(userID) {
 		return NGReasonNotSender
@@ -35,7 +35,7 @@ func (rcv *MorningCall) CanUpdate(userID string) NGReason {
 }
 
 // CanDelete checks if the morning call can be deleted
-func (rcv *MorningCall) CanDelete(userID string) NGReason {
+func (rcv *MorningCall) CanDelete(userID UserID) NGReason {
 	// 送信者または受信者が削除可能
 	if !rcv.IsSender(userID) && !rcv.IsReceiver(userID) {
 		return NGReasonNoPermission

--- a/internal/infrastructure/inmemory_morningcall_repository.go
+++ b/internal/infrastructure/inmemory_morningcall_repository.go
@@ -9,16 +9,16 @@ import (
 
 type inMemoryMorningCallRepository struct {
 	mu           sync.RWMutex
-	morningCalls map[string]*domain.MorningCall
+	morningCalls map[domain.MorningCallID]*domain.MorningCall
 }
 
 func NewInMemoryMorningCallRepository() *inMemoryMorningCallRepository {
 	return &inMemoryMorningCallRepository{
-		morningCalls: make(map[string]*domain.MorningCall),
+		morningCalls: make(map[domain.MorningCallID]*domain.MorningCall),
 	}
 }
 
-func (r *inMemoryMorningCallRepository) FindByID(ctx context.Context, id string) (*domain.MorningCall, error) {
+func (r *inMemoryMorningCallRepository) FindByID(ctx context.Context, id domain.MorningCallID) (*domain.MorningCall, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -37,7 +37,7 @@ func (r *inMemoryMorningCallRepository) Save(ctx context.Context, morningCall *d
 		return fmt.Errorf("morning call ID is required")
 	}
 
-	r.morningCalls[string(morningCall.ID)] = morningCall
+	r.morningCalls[morningCall.ID] = morningCall
 	return nil
 }
 
@@ -45,15 +45,15 @@ func (r *inMemoryMorningCallRepository) Update(ctx context.Context, morningCall 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if _, ok := r.morningCalls[string(morningCall.ID)]; !ok {
+	if _, ok := r.morningCalls[morningCall.ID]; !ok {
 		return fmt.Errorf("morning call not found: %s", morningCall.ID)
 	}
 
-	r.morningCalls[string(morningCall.ID)] = morningCall
+	r.morningCalls[morningCall.ID] = morningCall
 	return nil
 }
 
-func (r *inMemoryMorningCallRepository) Delete(ctx context.Context, id string) error {
+func (r *inMemoryMorningCallRepository) Delete(ctx context.Context, id domain.MorningCallID) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -65,7 +65,7 @@ func (r *inMemoryMorningCallRepository) Delete(ctx context.Context, id string) e
 	return nil
 }
 
-func (r *inMemoryMorningCallRepository) ListBySender(ctx context.Context, senderID string) ([]*domain.MorningCall, error) {
+func (r *inMemoryMorningCallRepository) ListBySender(ctx context.Context, senderID domain.UserID) ([]*domain.MorningCall, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -78,7 +78,7 @@ func (r *inMemoryMorningCallRepository) ListBySender(ctx context.Context, sender
 	return result, nil
 }
 
-func (r *inMemoryMorningCallRepository) ListByReceiver(ctx context.Context, receiverID string) ([]*domain.MorningCall, error) {
+func (r *inMemoryMorningCallRepository) ListByReceiver(ctx context.Context, receiverID domain.UserID) ([]*domain.MorningCall, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/internal/infrastructure/inmemory_user_repository.go
+++ b/internal/infrastructure/inmemory_user_repository.go
@@ -12,17 +12,17 @@ import (
 // inMemoryUserRepository は UserRepository のインメモリ実装です
 type inMemoryUserRepository struct {
 	mu    sync.RWMutex
-	users map[string]*domain.User
+	users map[domain.UserID]*domain.User
 }
 
 // NewInMemoryUserRepository は新しい inMemoryUserRepository を生成します
 func NewInMemoryUserRepository() repository.UserRepository {
 	return &inMemoryUserRepository{
-		users: make(map[string]*domain.User),
+		users: make(map[domain.UserID]*domain.User),
 	}
 }
 
-func (r *inMemoryUserRepository) FindByID(ctx context.Context, id string) (*domain.User, error) {
+func (r *inMemoryUserRepository) FindByID(ctx context.Context, id domain.UserID) (*domain.User, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/internal/repository/morningcall.go
+++ b/internal/repository/morningcall.go
@@ -6,6 +6,6 @@ import (
 )
 
 type MorningCallRepository interface {
-	FindByID(ctx context.Context, id string) (*domain.MorningCall, error)
+	FindByID(ctx context.Context, id domain.MorningCallID) (*domain.MorningCall, error)
 	Save(ctx context.Context, morningCall *domain.MorningCall) error
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -7,6 +7,6 @@ import (
 )
 
 type UserRepository interface {
-	FindByID(ctx context.Context, id string) (*domain.User, error)
+	FindByID(ctx context.Context, id domain.UserID) (*domain.User, error)
 	Create(ctx context.Context, user *domain.User) error
 }

--- a/internal/usecase/morningcall.go
+++ b/internal/usecase/morningcall.go
@@ -20,7 +20,7 @@ func NewMorningCallRepository(morningCallRepo repository.MorningCallRepository, 
 }
 
 func (rcv *morningCallUsecase) SaveFriendMorningCall(ctx context.Context, userID, friendID domain.UserID, morningCall *domain.MorningCall) error {
-	friend, err := rcv.userRepo.FindByID(ctx, string(friendID))
+	friend, err := rcv.userRepo.FindByID(ctx, friendID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request refactors the codebase to consistently use domain-specific ID types (`UserID` and `MorningCallID`) instead of plain strings for user and morning call identifiers. This change improves type safety and clarity throughout the domain, repository, and infrastructure layers. The update affects struct definitions, method signatures, and internal data structures.

**Domain Model Updates:**
* Changed the `SenderID` and `ReceiverID` fields in the `MorningCall` struct to use `UserID` instead of `string` for improved type safety (`internal/domain/morningcall.go`).

**Validation and Business Logic:**
* Updated all methods in `morningcall_validation.go` to accept and compare `UserID` types instead of strings, ensuring consistent usage of domain types (`internal/domain/morningcall_validation.go`). [[1]](diffhunk://#diff-0fdbbf98c84b78127b3a3dc63691ae25f7508e63dd653e9a24b1a15d794b3ff5L8-R18) [[2]](diffhunk://#diff-0fdbbf98c84b78127b3a3dc63691ae25f7508e63dd653e9a24b1a15d794b3ff5L38-R38)

**Repository and Infrastructure Layer:**
* Refactored the in-memory morning call repository to use `MorningCallID` as map keys and in method signatures, replacing string usage (`internal/infrastructure/inmemory_morningcall_repository.go`). [[1]](diffhunk://#diff-5eb8ab11c36a80e558cf3404461d09c429a79cb79afd25aaf85981b00a363274L12-R21) [[2]](diffhunk://#diff-5eb8ab11c36a80e558cf3404461d09c429a79cb79afd25aaf85981b00a363274L40-R56) [[3]](diffhunk://#diff-5eb8ab11c36a80e558cf3404461d09c429a79cb79afd25aaf85981b00a363274L68-R68) [[4]](diffhunk://#diff-5eb8ab11c36a80e558cf3404461d09c429a79cb79afd25aaf85981b00a363274L81-R81)
* Updated the in-memory user repository to use `UserID` as map keys and in method signatures, replacing string usage (`internal/infrastructure/inmemory_user_repository.go`).
* Changed the repository interfaces to require domain-specific ID types in their method signatures (`internal/repository/morningcall.go`, `internal/repository/user.go`). [[1]](diffhunk://#diff-bfc859d20d59d065fe06baafd155e0758998705765527a4c6383674263ff5ddfL9-R9) [[2]](diffhunk://#diff-f57712c95170b0f4d79c87004899f3a2bd266383db2bd55db226548edc05befeL10-R10)

**Use Case Layer:**
* Modified the use case logic to pass `UserID` directly to repository methods instead of converting to string (`internal/usecase/morningcall.go`).…type safety