### PR TITLE
Feature/phase1 repository layer

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5,12 +5,12 @@ import (
 	"net/http"
 
 	"morning-call/internal/handler"
-	"morning-call/internal/infrastructure"
+	"morning-call/internal/infrastructure/persistence/inmemory"
 	"morning-call/internal/usecase"
 )
 
 func main() {
-	userRepo := infrastructure.NewInMemoryUserRepository()
+	userRepo := inmemory.NewInMemoryUserRepository()
 	userUsecase := usecase.NewUserUsecase(userRepo)
 	userHandler := handler.NewUserHandler(userUsecase)
 

--- a/internal/infrastructure/persistence/inmemory/morningcall_repository.go
+++ b/internal/infrastructure/persistence/inmemory/morningcall_repository.go
@@ -1,9 +1,10 @@
-package infrastructure
+package inmemory
 
 import (
 	"context"
 	"fmt"
 	"morning-call/internal/domain"
+	"morning-call/internal/repository"
 	"sync"
 )
 
@@ -12,7 +13,7 @@ type inMemoryMorningCallRepository struct {
 	morningCalls map[domain.MorningCallID]*domain.MorningCall
 }
 
-func NewInMemoryMorningCallRepository() *inMemoryMorningCallRepository {
+func NewInMemoryMorningCallRepository() repository.MorningCallRepository {
 	return &inMemoryMorningCallRepository{
 		morningCalls: make(map[domain.MorningCallID]*domain.MorningCall),
 	}
@@ -65,7 +66,7 @@ func (r *inMemoryMorningCallRepository) Delete(ctx context.Context, id domain.Mo
 	return nil
 }
 
-func (r *inMemoryMorningCallRepository) ListBySender(ctx context.Context, senderID domain.UserID) ([]*domain.MorningCall, error) {
+func (r *inMemoryMorningCallRepository) ListBySenderID(ctx context.Context, senderID domain.UserID) ([]*domain.MorningCall, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -78,7 +79,7 @@ func (r *inMemoryMorningCallRepository) ListBySender(ctx context.Context, sender
 	return result, nil
 }
 
-func (r *inMemoryMorningCallRepository) ListByReceiver(ctx context.Context, receiverID domain.UserID) ([]*domain.MorningCall, error) {
+func (r *inMemoryMorningCallRepository) ListByReceiverID(ctx context.Context, receiverID domain.UserID) ([]*domain.MorningCall, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/internal/repository/morningcall.go
+++ b/internal/repository/morningcall.go
@@ -8,4 +8,8 @@ import (
 type MorningCallRepository interface {
 	FindByID(ctx context.Context, id domain.MorningCallID) (*domain.MorningCall, error)
 	Save(ctx context.Context, morningCall *domain.MorningCall) error
+	Update(ctx context.Context, morningCall *domain.MorningCall) error
+	Delete(ctx context.Context, id domain.MorningCallID) error
+	ListBySenderID(ctx context.Context, senderID domain.UserID) ([]*domain.MorningCall, error)
+	ListByReceiverID(ctx context.Context, receiverID domain.UserID) ([]*domain.MorningCall, error)
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -8,5 +8,8 @@ import (
 
 type UserRepository interface {
 	FindByID(ctx context.Context, id domain.UserID) (*domain.User, error)
+	FindByEmail(ctx context.Context, email string) (*domain.User, error)
 	Create(ctx context.Context, user *domain.User) error
+	Update(ctx context.Context, user *domain.User) error
+	UpdateRelatedUsers(ctx context.Context, userID domain.UserID, relatedUsers []domain.RelatedUser) error
 }

--- a/internal/usecase/interfaces.go
+++ b/internal/usecase/interfaces.go
@@ -1,0 +1,17 @@
+package usecase
+
+import (
+	"context"
+	"morning-call/internal/domain"
+)
+
+// UserUsecase defines the interface for user-related use cases
+type UserUsecase interface {
+	Register(ctx context.Context, username, email string) (*domain.User, error)
+}
+
+// MorningCallUsecase defines the interface for morning call-related use cases
+type MorningCallUsecase interface {
+	SaveFriendMorningCall(ctx context.Context, userID, friendID domain.UserID, morningCall *domain.MorningCall) error
+	GetFriendMorningCall(ctx context.Context, userID, friendID domain.UserID, morningCallID domain.MorningCallID) (*domain.MorningCall, error)
+}

--- a/internal/usecase/morningcall.go
+++ b/internal/usecase/morningcall.go
@@ -12,7 +12,7 @@ type morningCallUsecase struct {
 	userRepo        repository.UserRepository
 }
 
-func NewMorningCallRepository(morningCallRepo repository.MorningCallRepository, userRepo repository.UserRepository) *morningCallUsecase {
+func NewMorningCallUsecase(morningCallRepo repository.MorningCallRepository, userRepo repository.UserRepository) MorningCallUsecase {
 	return &morningCallUsecase{
 		morningCallRepo: morningCallRepo,
 		userRepo:        userRepo,

--- a/internal/usecase/user.go
+++ b/internal/usecase/user.go
@@ -13,7 +13,7 @@ type userUsecase struct {
 	userRepo repository.UserRepository
 }
 
-func NewUserUsecase(userRepo repository.UserRepository) *userUsecase {
+func NewUserUsecase(userRepo repository.UserRepository) UserUsecase {
 	return &userUsecase{
 		userRepo: userRepo,
 	}


### PR DESCRIPTION
This pull request refactors the in-memory persistence layer and repository interfaces to improve modularity and consistency, and adds new methods to support user and morning call management. The changes also introduce explicit usecase interfaces for better abstraction.

**Persistence Layer Refactor:**
* Moved in-memory repository implementations from the `infrastructure` package to the new `inmemory` package under `internal/infrastructure/persistence/inmemory`, and updated all references to use the new package. [[1]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL8-R13) [[2]](diffhunk://#diff-def58169c3129ea80b849f1e98380ae19a7f2a366a11d847fbf234475c99b4b8L1-R7) [[3]](diffhunk://#diff-3c98440787fd69b0d124add221dc61846cf1a7a62d7ff0533b147d6136441aa8L1-R1)

**Repository Interface Enhancements:**
* Added new methods to `UserRepository` and `MorningCallRepository` interfaces, including `FindByEmail`, `Update`, and `UpdateRelatedUsers` for users, and `Update`, `Delete`, `ListBySenderID`, and `ListByReceiverID` for morning calls. [[1]](diffhunk://#diff-f57712c95170b0f4d79c87004899f3a2bd266383db2bd55db226548edc05befeR11-R14) [[2]](diffhunk://#diff-bfc859d20d59d065fe06baafd155e0758998705765527a4c6383674263ff5ddfR11-R14)
* Renamed methods in the in-memory morning call repository for consistency (`ListBySender` → `ListBySenderID`, `ListByReceiver` → `ListByReceiverID`). [[1]](diffhunk://#diff-def58169c3129ea80b849f1e98380ae19a7f2a366a11d847fbf234475c99b4b8L68-R69) [[2]](diffhunk://#diff-def58169c3129ea80b849f1e98380ae19a7f2a366a11d847fbf234475c99b4b8L81-R82)

**Repository Implementation Updates:**
* Implemented the new methods (`FindByEmail`, `Update`, `UpdateRelatedUsers`) in the in-memory user repository.
* Changed constructors to return interface types instead of concrete types for better abstraction (`NewInMemoryMorningCallRepository`, `NewUserUsecase`, `NewMorningCallUsecase`). [[1]](diffhunk://#diff-def58169c3129ea80b849f1e98380ae19a7f2a366a11d847fbf234475c99b4b8L15-R16) [[2]](diffhunk://#diff-3895a8e61d19e65531e69c2610475244e55a9eb6ab1c30281419c19e0184bd7eL16-R16) [[3]](diffhunk://#diff-d4278697ff2644a4dd5b075ca8a104be0f0c16e3a3c9e543672efcb4af211cd8L15-R15)

**Usecase Layer Improvements:**
* Introduced explicit `UserUsecase` and `MorningCallUsecase` interfaces in `internal/usecase/interfaces.go` to define the contract for usecase implementations.